### PR TITLE
Add ability to set number of singers via admin controls

### DIFF
--- a/azunyan.go
+++ b/azunyan.go
@@ -25,6 +25,7 @@ func main() {
 	env := manager.Initialize(confFileLoc)
 
 	db.InitialiseState(&env)
+	db.ClearUpcomingSongs(&env)
 
 	//Start listening for web requests
 	router := webserver.Route(env)

--- a/db/completedRequest.go
+++ b/db/completedRequest.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/callummance/azunyan/models"
+	"github.com/globalsign/mgo/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// AddSongToUpcomingQueue adds a song to the upcomingQueue collection to mark that a song
+// has fulfilled the required number of singers and has entered upcoming queue.
+func AddSongToUpcomingQueue(env databaseConfig, requestID primitive.ObjectID, queueItem models.QueueItem) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	upcomingQueueItem := models.UpcomingQueueItem{
+		RequestID: requestID,
+		QueueItem: queueItem,
+	}
+
+	_, err := getCompletedReqCollection(env).InsertOne(ctx, upcomingQueueItem)
+	if err != nil {
+		env.GetLog().Printf("Could not insert upcoming queue item; encountered error %q", err)
+	}
+}
+
+// RemoveSongFromUpcomingQueue removes a song from the upcomingQueue collection. This should be called
+// when the song has been played.
+func RemoveSongFromUpcomingQueue(env databaseConfig, queueItemID primitive.ObjectID) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := getCompletedReqCollection(env).DeleteMany(ctx, bson.M{"queueitem.queueitemid": queueItemID})
+	if err != nil {
+		env.GetLog().Printf("Could not remove from upcoming queue item; encountered error %q", err)
+	}
+	if res.DeletedCount == 0 {
+		env.GetLog().Printf("Could not remove queue id %s from upcoming queue item", queueItemID.Hex())
+	}
+}
+
+// GetUpcomingSongs retrieves the documents in upcomingqueue
+func GetUpcomingSongs(env databaseConfig) map[primitive.ObjectID]models.UpcomingQueueItem {
+	col := getCompletedReqCollection(env)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	mapRes := make(map[primitive.ObjectID]models.UpcomingQueueItem)
+
+	cursor, err := col.Find(ctx, bson.M{})
+	if err != nil {
+		env.GetLog().Printf("Failure whilst retrieving upcoming queue; error %q", err)
+		return mapRes
+	}
+	for cursor.Next(ctx) {
+		var upcomingQueueItem models.UpcomingQueueItem
+		cursor.Decode(&upcomingQueueItem)
+		mapRes[upcomingQueueItem.RequestID] = upcomingQueueItem
+	}
+	return mapRes
+}
+
+// ClearUpcomingSongs deletes all documents in upcomingqueue collection
+func ClearUpcomingSongs(env databaseConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := getCompletedReqCollection(env).DeleteMany(ctx, bson.M{})
+	if err != nil {
+		env.GetLog().Printf("Failure whilst trying to clear upcoming queue; error %q", err)
+	}
+}
+
+func getCompletedReqCollection(env databaseConfig) *mongo.Collection {
+	return env.GetClient().Database(env.GetConfig().DbConfig.DatabaseName).Collection("upcomingqueue")
+}

--- a/db/request.go
+++ b/db/request.go
@@ -181,13 +181,13 @@ func GetPreviousRequestsBySinger(env databaseConfig, singer string, submitted ti
 	return res
 }
 
-func GetQueued(env databaseConfig) []models.Request {
+func GetLiveRequests(env databaseConfig) []models.Request {
 	var res []models.Request
 	col := getReqCollection(env)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	findOptions := options.Find()
-	findOptions.SetSort("-priority")
+	findOptions.SetSort(bson.M{"time": 1})
 	cursor, err := col.Find(ctx, bson.M{
 		"playedtime": bson.M{"$exists": false},
 	}, findOptions)
@@ -208,7 +208,7 @@ func SetRequestPlayed(env databaseConfig, reqId primitive.ObjectID, playedTime t
 	defer cancel()
 	_, err := col.UpdateOne(ctx, bson.M{"_id": reqId}, bson.M{"$set": bson.M{"playedtime": playedTime}})
 	if err != nil {
-		env.GetLog().Printf("Couldn't update priority due to error %q", err)
+		env.GetLog().Printf("Couldn't update playedtime due to error %q", err)
 	}
 	return err
 }

--- a/manager/karaoke_manager.go
+++ b/manager/karaoke_manager.go
@@ -11,7 +11,7 @@ import (
 	mgo "go.mongodb.org/mongo-driver/mongo"
 )
 
-// KaraokeManager object
+// KaraokeManager object implements databaseConfig interface
 type KaraokeManager struct {
 	DbClient          *mgo.Client
 	Logger            *log.Logger

--- a/manager/queue.go
+++ b/manager/queue.go
@@ -11,58 +11,50 @@ import (
 	"github.com/callummance/azunyan/models"
 )
 
-//GetQueue returns an ordered list of wating queue items and an ordered list of
-//requests still waiting for more singers.
+/*GetQueue returns an ordered list of waiting queue items and an ordered list of
+  requests still waiting for more singers.
+*/
 func GetQueue(m *KaraokeManager) ([]models.QueueItem, []models.QueueItem, error) {
-	enqueuedSongs, err := db.GetLiveAggregatedSongRequests(m)
-	if err != nil {
-		m.Logger.Printf("Failed to get list of queued songs due to error %v", err)
-		return nil, nil, err
-	}
-	state, err := db.GetEngineState(m, m.Config.KaraokeConfig.SessionName)
-	if err != nil {
-		m.Logger.Printf("Failed to get engine statedue to error %v", err)
-		return nil, nil, err
-	}
+	requests := db.GetLiveRequests(m)
+	upcomingSongs := db.GetUpcomingSongs(m)
 
-	//Convert reqs to queueItems and sore into incomplete and complete queue items
 	var filledItems []models.QueueItem
 	var waitingItems []models.QueueItem
-	for sid, rs := range enqueuedSongs {
-		shouldRemoveBecauseDupe := false
-		if !state.AllowingDupes {
-			isDupe, err := IsDupeRequest(m, sid)
-			if err != nil {
-				m.Logger.Printf("Could not check if song %q was a duplicate, allowing request...")
+	requestsAdded := make(map[primitive.ObjectID]bool)
+	leftoverRequests := make(map[primitive.ObjectID][]models.Request)
+
+	for i := 0; i < len(requests); i++ {
+		// Check if in upcoming queue already
+		request := requests[i]
+		if upcomingqueueitem, present := upcomingSongs[request.ReqID]; present {
+			if !requestsAdded[upcomingqueueitem.QueueItem.QueueItemID] {
+				queueItem := models.QueueItem{
+					RequestIDs:   upcomingqueueitem.QueueItem.RequestIDs,
+					QueueItemID:  upcomingqueueitem.QueueItem.QueueItemID,
+					SongID:       upcomingqueueitem.QueueItem.SongID,
+					SongTitle:    upcomingqueueitem.QueueItem.SongTitle,
+					SongArtist:   upcomingqueueitem.QueueItem.SongArtist,
+					Singers:      upcomingqueueitem.QueueItem.Singers,
+					RequestTimes: upcomingqueueitem.QueueItem.RequestTimes,
+				}
+				filledItems = append(filledItems, queueItem)
+				requestsAdded[upcomingqueueitem.QueueItem.QueueItemID] = true
+			}
+
+		} else {
+			if rqs, present := leftoverRequests[request.Song]; present {
+				newReqs := append(rqs, request)
+				leftoverRequests[request.Song] = newReqs
 			} else {
-				shouldRemoveBecauseDupe = isDupe
-			}
-		}
-		if !shouldRemoveBecauseDupe {
-			song, err := db.GetSongByID(m, sid)
-			if err != nil {
-				m.Logger.Printf("Failed to get details of queued song %v due to error %v", sid, err)
-				continue
-			}
-			completedQueue, incompleteQueue := models.CompileQueueItems(rs, song, state.NoSingers)
-			if completedQueue != nil && len(completedQueue) != 0 {
-				filledItems = append(filledItems, completedQueue...)
-			}
-			if incompleteQueue != nil {
-				waitingItems = append(waitingItems, *incompleteQueue)
+				reqSlice := []models.Request{request}
+				leftoverRequests[request.Song] = reqSlice
 			}
 		}
 	}
-
-	//Sort the waiting lists
-	now := time.Now()
-	sort.Slice(filledItems, func(i int, j int) bool {
-		return getWaitingTime(&filledItems[i], now) > getWaitingTime(&filledItems[j], now)
-	})
-	sort.Slice(waitingItems, func(i int, j int) bool {
-		return getWaitingTime(&waitingItems[i], now) > getWaitingTime(&waitingItems[j], now)
-	})
-
+	completedQueue, incompleteQueue, _ := getQueueHelper(m, leftoverRequests)
+	filledItems = append(filledItems, completedQueue...)
+	waitingItems = append(waitingItems, incompleteQueue...)
+	filledItems, waitingItems = sortQueues(filledItems, waitingItems)
 	return filledItems, waitingItems, nil
 }
 
@@ -107,26 +99,27 @@ func PopNextSong(m *KaraokeManager) (*models.QueueItem, error) {
 		return nil, err
 	}
 	next := getNext(completeQueue, partialQueue)
+	var origState models.State
+	curState, err := db.GetEngineState(m, m.GetConfig().KaraokeConfig.SessionName)
+	if err != nil {
+		m.Logger.Printf("Failed to get karaoke engine state due to error %v", err)
+		return nil, err
+	}
+	origState = *curState
 	if next != nil {
 		m.Logger.Printf("Popping next song")
 		markQueueItemPlayed(m, next)
-		var origState models.State
-		curState, err := db.GetEngineState(m, m.GetConfig().KaraokeConfig.SessionName)
-		if err != nil {
-			m.Logger.Printf("Failed to get karaoke engine state due to error %v", err)
-			return nil, err
-		} else {
-			origState = *curState
-		}
 		origState.NowPlaying = next
 		db.UpdateEngineState(m, origState)
-		UpdateListenersQueue(m, removeNowPlayingFromList(next, completeQueue), removeNowPlayingFromList(next, partialQueue))
+		db.RemoveSongFromUpcomingQueue(m, next.QueueItemID)
+		UpdateListenersQueue(m, removeNowPlayingFromList(next, completeQueue), removeNowPlayingFromList(next, partialQueue), 0)
 	} else {
 		m.Logger.Printf("No more songs left in queue")
-		db.ClearEngineState(m)
 		newState := models.InitSession(m.GetConfig())
 		newState.IsActive = true
 		newState.RequestsActive = true
+		newState.NoSingers = origState.NoSingers
+		db.ClearEngineState(m)
 		db.UpdateEngineState(m, newState)
 	}
 	UpdateListenersCur(m, next)
@@ -143,6 +136,64 @@ func IsDupeRequest(m *KaraokeManager, sid primitive.ObjectID) (bool, error) {
 	return len(prevRequests) > m.Config.KaraokeConfig.NoSingers, nil
 }
 
+//CompileQueueItems takes a list of requests for a song, as well as the song's
+//struct itself and the number of singers which can be contained in a single
+//queued item and returns a slice of complete queue items along with an optional
+//incomplete queue item.
+func CompileQueueItems(m *KaraokeManager, reqs []models.Request, song *models.Song, maxSingers int) ([]models.QueueItem, *models.QueueItem) {
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+
+	noRequests := len(reqs)
+	incompleteQueueLen := noRequests % maxSingers
+	fullQueueItemsCount := noRequests / maxSingers
+	completeRes := make([]models.QueueItem, fullQueueItemsCount)
+
+	for i := 0; i < fullQueueItemsCount; i++ {
+		item := models.QueueItem{
+			QueueItemID:  primitive.NewObjectID(),
+			SongID:       song.ID,
+			SongTitle:    song.Title,
+			SongArtist:   song.Artist,
+			RequestIDs:   []primitive.ObjectID{},
+			Singers:      []string{},
+			RequestTimes: []time.Time{},
+		}
+		for j := 0; j < maxSingers; j++ {
+			offset := i*maxSingers + j
+			item.RequestIDs = append(item.RequestIDs, reqs[offset].ReqID)
+			item.Singers = append(item.Singers, reqs[offset].Singer)
+			item.RequestTimes = append(item.RequestTimes, reqs[offset].ReqTime)
+		}
+		completeRes[i] = item
+
+		for _, reqID := range item.RequestIDs {
+			db.AddSongToUpcomingQueue(m, reqID, item)
+		}
+
+	}
+
+	if incompleteQueueLen != 0 {
+		item := models.QueueItem{
+			SongID:       song.ID,
+			SongTitle:    song.Title,
+			SongArtist:   song.Artist,
+			RequestIDs:   []primitive.ObjectID{},
+			Singers:      []string{},
+			RequestTimes: []time.Time{},
+		}
+		for j := 0; j < incompleteQueueLen; j++ {
+			offset := fullQueueItemsCount*maxSingers + j
+			item.RequestIDs = append(item.RequestIDs, reqs[offset].ReqID)
+			item.Singers = append(item.Singers, reqs[offset].Singer)
+			item.RequestTimes = append(item.RequestTimes, reqs[offset].ReqTime)
+		}
+		return completeRes, &item
+	}
+	return completeRes, nil
+}
+
 func removeNowPlayingFromList(np *models.QueueItem, list []models.QueueItem) []models.QueueItem {
 	updated := make([]models.QueueItem, 0)
 	for _, v := range list {
@@ -157,4 +208,56 @@ func markQueueItemPlayed(m *KaraokeManager, i *models.QueueItem) {
 	for _, rid := range i.RequestIDs {
 		db.SetRequestPlayed(m, rid, time.Now())
 	}
+}
+
+func getQueueHelper(m *KaraokeManager, enqueuedSongs map[primitive.ObjectID][]models.Request) ([]models.QueueItem, []models.QueueItem, error) {
+	//Convert reqs to queueItems and sort into incomplete and complete queue items
+	var filledItems []models.QueueItem
+	var waitingItems []models.QueueItem
+
+	state, err := db.GetEngineState(m, m.Config.KaraokeConfig.SessionName)
+	if err != nil {
+		m.Logger.Printf("Failed to get engine statedue to error %v", err)
+		return nil, nil, err
+	}
+
+	for sid, rs := range enqueuedSongs {
+		shouldRemoveBecauseDupe := false
+		if !state.AllowingDupes {
+			isDupe, err := IsDupeRequest(m, sid)
+			if err != nil {
+				m.Logger.Printf("Could not check if song %q was a duplicate, allowing request...", sid)
+			} else {
+				shouldRemoveBecauseDupe = isDupe
+			}
+		}
+
+		if !shouldRemoveBecauseDupe {
+			song, err := db.GetSongByID(m, sid)
+			if err != nil {
+				m.Logger.Printf("Failed to get details of queued song %v due to error %v", sid, err)
+				continue
+			}
+			completedQueue, incompleteQueue := CompileQueueItems(m, rs, song, state.NoSingers)
+			if completedQueue != nil && len(completedQueue) != 0 {
+				filledItems = append(filledItems, completedQueue...)
+			}
+			if incompleteQueue != nil {
+				waitingItems = append(waitingItems, *incompleteQueue)
+			}
+		}
+	}
+	return filledItems, waitingItems, nil
+}
+
+func sortQueues(filledItems []models.QueueItem, waitingItems []models.QueueItem) ([]models.QueueItem, []models.QueueItem) {
+	//Sort the waiting lists
+	now := time.Now()
+	sort.Slice(filledItems, func(i int, j int) bool {
+		return getWaitingTime(&filledItems[i], now) > getWaitingTime(&filledItems[j], now)
+	})
+	sort.Slice(waitingItems, func(i int, j int) bool {
+		return getWaitingTime(&waitingItems[i], now) > getWaitingTime(&waitingItems[j], now)
+	})
+	return filledItems, waitingItems
 }

--- a/models/request.go
+++ b/models/request.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	// "gopkg.in/mgo.v2/bson"
 )
 
 //Request contains details on a single request that someone made for a song.
@@ -20,63 +19,13 @@ type Request struct {
 //QueueItem contains details on an enqueued song, aggregated from its
 //requests
 type QueueItem struct {
-	RequestIDs   []primitive.ObjectID `json:"ids"`
-	SongID       primitive.ObjectID   `json:"sid"`
-	SongTitle    string               `json:"title"`
-	SongArtist   string               `json:"artist"`
-	Singers      []string             `json:"singers"`
-	RequestTimes []time.Time          `json:"times"`
-}
-
-//CompileQueueItems takes a list of requests for a song, as well as the song's
-//struct itself and the number of singers which can be contained in a single
-//queued item and returns a slice of complete queue items along with an optional
-//incomplete queue item.
-func CompileQueueItems(reqs []Request, song *Song, maxSingers int) ([]QueueItem, *QueueItem) {
-	if len(reqs) == 0 {
-		return nil, nil
-	}
-	noRequests := len(reqs)
-	incompleteQueueLen := noRequests % maxSingers
-	fullQueueItemsCount := noRequests / maxSingers
-	completeRes := make([]QueueItem, fullQueueItemsCount)
-
-	for i := 0; i < fullQueueItemsCount; i++ {
-		item := QueueItem{
-			SongID:       song.ID,
-			SongTitle:    song.Title,
-			SongArtist:   song.Artist,
-			RequestIDs:   []primitive.ObjectID{},
-			Singers:      []string{},
-			RequestTimes: []time.Time{},
-		}
-		for j := 0; j < maxSingers; j++ {
-			offset := i*maxSingers + j
-			item.RequestIDs = append(item.RequestIDs, reqs[offset].ReqID)
-			item.Singers = append(item.Singers, reqs[offset].Singer)
-			item.RequestTimes = append(item.RequestTimes, reqs[offset].ReqTime)
-		}
-		completeRes[i] = item
-	}
-
-	if incompleteQueueLen != 0 {
-		item := QueueItem{
-			SongID:       song.ID,
-			SongTitle:    song.Title,
-			SongArtist:   song.Artist,
-			RequestIDs:   []primitive.ObjectID{},
-			Singers:      []string{},
-			RequestTimes: []time.Time{},
-		}
-		for j := 0; j < incompleteQueueLen; j++ {
-			offset := fullQueueItemsCount*maxSingers + j
-			item.RequestIDs = append(item.RequestIDs, reqs[offset].ReqID)
-			item.Singers = append(item.Singers, reqs[offset].Singer)
-			item.RequestTimes = append(item.RequestTimes, reqs[offset].ReqTime)
-		}
-		return completeRes, &item
-	}
-	return completeRes, nil
+	QueueItemID  primitive.ObjectID   `json:"queueitemid" bson:"queueitemid"`
+	RequestIDs   []primitive.ObjectID `json:"ids" bson:"reqids"`
+	SongID       primitive.ObjectID   `json:"sid" bson:"songid"`
+	SongTitle    string               `json:"title" bson:"title"`
+	SongArtist   string               `json:"artist" bson:"artist"`
+	Singers      []string             `json:"singers" bson:"singers"`
+	RequestTimes []time.Time          `json:"times" bson:"times"`
 }
 
 type AbbreviatedQueueItem struct {

--- a/models/upcomingQueueItem.go
+++ b/models/upcomingQueueItem.go
@@ -1,0 +1,10 @@
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type UpcomingQueueItem struct {
+	RequestID primitive.ObjectID `json:"ID" bson:"_id"`
+	QueueItem QueueItem          `json:"queueitem" bson:"queueitem"`
+}

--- a/static/frontend/admin/admin.js
+++ b/static/frontend/admin/admin.js
@@ -105,6 +105,10 @@ function AdminPanel() {
         jQuery.post('/admin/reset_queue');
         reset_modal.style.display = "none";
     });
+    $("input[name='singersInput'").change(() => {
+        let value = $("input[name='singersInput'").val();
+        jQuery.post('/admin/singers/'+value);
+    });
         
     $(document).keypress(function(e) {
         //Also advance on space bar

--- a/static/frontend/admin/adminpage.html
+++ b/static/frontend/admin/adminpage.html
@@ -22,6 +22,9 @@
     <button id = "removeActivate" class = "settings">Remove Singer</button>
     <br><br>
     <button id = "resetActivate" class = "settings">Reset Queue (DANGER)</button>
+    <div class = "settings__input">
+        Number of singers (1-4): <input type="number" name="singersInput" min="1" max="4">
+    </div>
 </div>
 
 

--- a/static/frontend/admin/adminstyle.css
+++ b/static/frontend/admin/adminstyle.css
@@ -32,6 +32,11 @@
     color: black;
 }
 
+.settings__input {
+    margin: 15px;
+    font-size: 2rem;
+}
+
 #controls {
     width: 100%;
     text-align: center;

--- a/static/frontend/display/display.css
+++ b/static/frontend/display/display.css
@@ -154,7 +154,6 @@ body {
 .queueitem {
     border-radius: 5px;
     margin: 0 auto 10px;
-    height:50px;
     width: 100%;
     background: #4e5664;
     position: relative;
@@ -211,7 +210,6 @@ body {
   background-color: darkgrey;
   margin: 5px;
   padding-left: 10px;
-  flex: 1;
 }
 
 .partialSongDetails {
@@ -294,10 +292,29 @@ body {
 
 /* For mobile screens */
 @media only screen and (max-width: 1024px) {
+
+    #queue::-webkit-scrollbar {
+        display: block;
+    }
+
+    #queue::-webkit-scrollbar:vertical {
+        width: 10px;
+    }
+      
+    #queue::-webkit-scrollbar-thumb {
+        border-radius: 5px;
+        background-color: rgba(0,0,0,.5);
+        -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+    }
+
+    #queue {
+        height: 550px;
+    }
+
     #nowplaying {
       width: 100%;
       margin: 0;
-      height: fit-content;
+      height: auto;
     }
 
     .mainbody_title {
@@ -354,6 +371,28 @@ body {
 
     #mainbody {
         min-width: 0; /* Fixes Firefox spacing issues with Flexbox */
-        height: unset;
+        height: max-content
+    }
+
+    #waiting {
+        height: 340px;
+    }
+
+    #waiting::-webkit-scrollbar {
+        display: block;
+    }
+
+    #waiting::-webkit-scrollbar:horizontal {
+        height: 10px;
+    }
+      
+    #waiting::-webkit-scrollbar-thumb {
+        border-radius: 5px;
+        background-color: rgba(0,0,0,.5);
+        -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+    }
+
+    ::-webkit-scrollbar-corner {
+        background-color: transparent;
     }
 }

--- a/static/frontend/display/display.js
+++ b/static/frontend/display/display.js
@@ -43,8 +43,14 @@ function DisplayClient() {
     });
     //Listen for SSEs
     this.source.addEventListener('queue',  function(e) {
-        client.queue = JSON.parse(e.data);
+        data = JSON.parse(e.data)
+        mode = data.Mode;
+        client.queue = data.Queues;
         client.queuedisplay = makeQueueDivs(client.queue, client.queuedisplay, client.cur, $('#queue'));
+        if (mode == 1) {
+            $('#waiting').empty()
+            this.partialqueuedisplay = {};
+        }
         client.partialqueuedisplay = makePartialQueueDivs(client.queue, client.partialqueuedisplay, client.cur, $('#waiting'), client.noSingers)
     });
     this.source.addEventListener('cur', function(e) {
@@ -57,6 +63,9 @@ function DisplayClient() {
     });
     this.source.addEventListener('message', function(e) {
         client.message.text = JSON.parse(e.data).message;
+    });
+    this.source.addEventListener('singers', function(e) {
+        client.noSingers = parseInt(e.data);
     });
 }
 
@@ -213,7 +222,7 @@ function makePartialQueueDivs(queue, prevQueueDivs, nowPlaying, targetDiv, noSin
           } else {
             targetDiv.append(prevQueueDivs[itemid])
             if (nowPlaying.ids != q_entry.ids) {
-                newQueueDisplay[q_entry.ids] = prevQueueDivs[itemid]
+                newQueueDisplay[itemid] = prevQueueDivs[itemid]
             }
           }
 

--- a/webserver/admin.go
+++ b/webserver/admin.go
@@ -1,6 +1,8 @@
 package webserver
 
 import (
+	"strconv"
+
 	"github.com/callummance/azunyan/manager"
 	"github.com/gin-gonic/gin"
 )
@@ -11,6 +13,7 @@ func RouteAdmin(group *gin.RouterGroup) {
 	group.POST("/advance", advanceEndpoint)
 	group.POST("/remove_singer", removeSingerEndpoint)
 	group.POST("/reset_queue", resetQueueEndpoint)
+	group.POST("/singers/:number", changeNumberOfSingersEndpoint)
 }
 
 func resetQueueEndpoint(c *gin.Context) {
@@ -95,5 +98,17 @@ func advanceEndpoint(c *gin.Context) {
 	}
 
 	manager.PopNextSong(env)
+	c.Status(201)
+}
+
+func changeNumberOfSingersEndpoint(c *gin.Context) {
+	env, ok := c.MustGet("manager").(*manager.KaraokeManager)
+	if !ok {
+		env.Logger.Printf("Failed to grab environment from Context variable")
+		c.String(500, "{\"message\": \"internal failure\"")
+	}
+	singersString := c.Param("number")
+	singers, _ := strconv.Atoi(singersString)
+	manager.ChangeNumberOfSingers(env, singers)
 	c.Status(201)
 }

--- a/webserver/stream/streamapi.go
+++ b/webserver/stream/streamapi.go
@@ -47,9 +47,15 @@ func sendInitial(m *manager.KaraokeManager, listener chan interface{}) {
 
 	listener <- manager.BroadcastData{
 		Name: "queue",
-		Content: map[string][]models.QueueItem{
-			"complete": completeQueue,
-			"partial":  partialQueue,
+		Content: struct {
+			Mode   int
+			Queues map[string][]models.QueueItem
+		}{
+			0,
+			map[string][]models.QueueItem{
+				"complete": completeQueue,
+				"partial":  partialQueue,
+			},
 		},
 	}
 	listener <- manager.BroadcastData{


### PR DESCRIPTION
For this to happen, another collection is now used to retain upcoming queue.
This is needed as if number of singers is modified during a session
and the browser is refreshed then the requests in the upcoming queue may
fragmented or pushed back to the awaiting queue. Having this second
collection to keep track of which items have fulfilled the singer
requirements before allows us to keep the upcoming queue intact.
This requires rewriting a key part of the getqueue logic to make
use of this new collection.

In addition, it's possible that when the number of singers requirement
is reduced, some of the awaiting songs can be added to the upcoming queue.
In order to make sure this is reflected, we need to update the
client.singers value and also tell the display to
rebuild the partialQueue divs. This is done by added a extra mode
parameter to the broadcast data.

Also:
- Fixed some styling issues...again.