### PR TITLE
Add duplicate songs setting to admin panel

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,14 +11,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:347f6f564daa892beb7af91931fd672dafc5562d1195fc18f7fe54b0a29bc871"
-  name = "github.com/callummance/fuwafuwasearch"
-  packages = ["levenshteinmatrix"]
-  pruneopts = "UT"
-  revision = "df810dd2259ef1d0c75e3e38f37db238ed7f68ad"
-
-[[projects]]
-  branch = "master"
   digest = "1:09caacaac48b388502b23d8afbc58003d0e3ec8d4faf78a866d4cde554d946f7"
   name = "github.com/dustin/go-broadcast"
   packages = ["."]
@@ -88,7 +80,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:be97e109f627d3ba8edfef50c9c74f0d0c17cbe3a2e924a8985e4804a894f282"
+  digest = "1:9a855f51d5eaf25dafc30cf0ad5844d5fb6aacec4ceb98a04ed2964562edbc0c"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
@@ -223,7 +215,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
-    "github.com/callummance/fuwafuwasearch/levenshteinmatrix",
     "github.com/dustin/go-broadcast",
     "github.com/gin-gonic/gin",
     "github.com/globalsign/mgo/bson",

--- a/manager/karaoke.go
+++ b/manager/karaoke.go
@@ -125,3 +125,19 @@ func ChangeNumberOfSingers(m *KaraokeManager, noSingers int) error {
 	FetchAndUpdateListenersQueue(m, 1)
 	return nil
 }
+
+//ChangeAllowDuplication changes whether duplicate songs should be allowed.
+func ChangeAllowDuplication(m *KaraokeManager, allowdupes bool) error {
+	state, err := db.GetEngineState(m, m.Config.KaraokeConfig.SessionName)
+	if err != nil {
+		m.Logger.Printf("Failed to get session data due to error %q", err)
+	}
+	state.AllowingDupes = allowdupes
+	err = db.UpdateEngineState(m, *state)
+	if err != nil {
+		m.Logger.Printf("Failed to update duplicate rule due to error %q", err)
+		return err
+	}
+	FetchAndUpdateListenersQueue(m, 1)
+	return nil
+}

--- a/static/frontend/admin/admin.js
+++ b/static/frontend/admin/admin.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
     let panel = new AdminPanel();
 })();
 
@@ -13,10 +13,10 @@ function AdminPanel() {
 
     //Load and subscribe to event source
     this.source = new window.EventSource('/api/queuestream');
-    this.source.addEventListener('queue', function(e) {
+    this.source.addEventListener('queue', function (e) {
         admin.queue = JSON.parse(e.data);
     });
-    this.source.addEventListener('cur', function(e) {
+    this.source.addEventListener('cur', function (e) {
         if (e == null || e == undefined || e.data == "<nil>") {
             console.log("Nothing left in queue");
             admin.nowPlaying = {};
@@ -26,18 +26,18 @@ function AdminPanel() {
         try {
             admin.nowPlaying = JSON.parse(e.data);
             admin.setPlaying();
-        } catch(error) {
+        } catch (error) {
             console.log(e);
             console.log(error);
         }
     });
-    this.source.addEventListener('active', function(e) {
+    this.source.addEventListener('active', function (e) {
         admin.active = JSON.parse(e.data).active;
     });
 
 
     //Functions for updating display elements
-    this.setPlaying = function() {
+    this.setPlaying = function () {
         $('#nowPlaying').text(admin.nowPlaying.title + " - " + admin.nowPlaying.artist);
     };
 
@@ -46,9 +46,9 @@ function AdminPanel() {
     let remove_btn = document.getElementById("removeActivate");
     let remove_span = document.getElementById("close_remove");
 
-    remove_btn.onclick = function() {remove_modal.style.display = "block";};
-    remove_span.onclick = function() {remove_modal.style.display = "none";};
-    window.onclick = function(event) {
+    remove_btn.onclick = function () { remove_modal.style.display = "block"; };
+    remove_span.onclick = function () { remove_modal.style.display = "none"; };
+    window.onclick = function (event) {
         if (event.target == remove_modal) {
             remove_modal.style.display = "none";
         }
@@ -59,72 +59,85 @@ function AdminPanel() {
     let reset_btn = document.getElementById("resetActivate");
     let reset_span = document.getElementById("close_reset");
 
-    reset_btn.onclick = function() {reset_modal.style.display = "block";};
-    reset_span.onclick = function() {reset_modal.style.display = "none";};
-    window.onclick = function(event) {
+    reset_btn.onclick = function () { reset_modal.style.display = "block"; };
+    reset_span.onclick = function () { reset_modal.style.display = "none"; };
+    window.onclick = function (event) {
         if (event.target == reset_modal) {
             reset_modal.style.display = "none";
         }
     };
 
     //Listen for button presses
-    $('#advance').click(function() {jQuery.post('/admin/advance');});
-    $('#activate').click(function() {jQuery.ajax({
-        type: "POST",
-        url: '/admin/active',
-        data: JSON.stringify({"active": true}),
-        contentType: 'application/json'
-    });});
-    $('#deactivate').click(function() {jQuery.ajax({
-        type: "POST",
-        url: '/admin/active',
-        data: JSON.stringify({"active": false}),
-        contentType: 'application/json'
-    });});
-    $('#activater').click(function() {jQuery.ajax({
-        type: "POST",
-        url: '/admin/req_active',
-        data: JSON.stringify({"active": true}),
-        contentType: 'application/json'
-    });});
-    $('#deactivater').click(function() {jQuery.ajax({
-        type: "POST",
-        url: '/admin/req_active',
-        data: JSON.stringify({"active": false}),
-        contentType: 'application/json'
-    });});
-    $('#sendDelete').click(function() {jQuery.ajax({
-          type: "POST",
-          url: '/admin/remove_singer',
-          data: JSON.stringify({"singer": $('#removeName').val()}),
-          contentType: 'application/json'
-      });
-      remove_modal.style.display = "none";
+    $('#advance').click(function () { jQuery.post('/admin/advance'); });
+    $('#activate').click(function () {
+        jQuery.ajax({
+            type: "POST",
+            url: '/admin/active',
+            data: JSON.stringify({ "active": true }),
+            contentType: 'application/json'
+        });
     });
-    $('#sendReset').click(function() {
+    $('#deactivate').click(function () {
+        jQuery.ajax({
+            type: "POST",
+            url: '/admin/active',
+            data: JSON.stringify({ "active": false }),
+            contentType: 'application/json'
+        });
+    });
+    $('#activater').click(function () {
+        jQuery.ajax({
+            type: "POST",
+            url: '/admin/req_active',
+            data: JSON.stringify({ "active": true }),
+            contentType: 'application/json'
+        });
+    });
+    $('#deactivater').click(function () {
+        jQuery.ajax({
+            type: "POST",
+            url: '/admin/req_active',
+            data: JSON.stringify({ "active": false }),
+            contentType: 'application/json'
+        });
+    });
+    $('#sendDelete').click(function () {
+        jQuery.ajax({
+            type: "POST",
+            url: '/admin/remove_singer',
+            data: JSON.stringify({ "singer": $('#removeName').val() }),
+            contentType: 'application/json'
+        });
+        remove_modal.style.display = "none";
+    });
+    $('#sendReset').click(function () {
         jQuery.post('/admin/reset_queue');
         reset_modal.style.display = "none";
     });
-    $("input[name='singersInput'").change(() => {
+    $("input[name='singersInput']").change(() => {
         let value = $("input[name='singersInput'").val();
-        jQuery.post('/admin/singers/'+value);
+        jQuery.post('/admin/singers/' + value);
     });
-        
-    $(document).keypress(function(e) {
+    $("input[name='allowDuplicates']").change(() => {
+        let value = $("input[name='allowDuplicates']").prop("checked");
+        jQuery.post('/admin/allowdupes/' + value);
+    });
+
+    $(document).keypress(function (e) {
         //Also advance on space bar
         if (e.which == 32) {
-          let remove_modal = document.getElementById('removeModal');
-          if (remove_modal.style.display == "none") {
-            jQuery.post('/admin/advance');
-          }
+            let remove_modal = document.getElementById('removeModal');
+            if (remove_modal.style.display == "none") {
+                jQuery.post('/admin/advance');
+            }
         }
     });
 }
 
 function loadQueue(id) {
-    $.getJSON('/admin/get_queue', function(data) {
+    $.getJSON('/admin/get_queue', function (data) {
         let rows = [];
-        $.each(data, function(i, obj) {
+        $.each(data, function (i, obj) {
             let titleDiv = document.createElement('div');
             titleDiv.className = "cell";
             titleDiv.append(obj.title);
@@ -141,7 +154,7 @@ function loadQueue(id) {
             let modBox = document.createElement('input');
             modBox.type = "number";
             modBox.value = obj.mod;
-            modBox.onblur = function() {
+            modBox.onblur = function () {
                 let id = obj.queuePos;
                 let newVal = modBox.value;
                 jQuery.ajax({
@@ -160,12 +173,12 @@ function loadQueue(id) {
             let delDiv = document.createElement('div');
             let delBut = document.createElement('button');
             delBut.innerText = "Remove";
-            delBut.onclick = function() {
+            delBut.onclick = function () {
                 let id = obj.queuePos;
                 jQuery.ajax({
                     type: "DELETE",
                     url: '/admin/remove_queue',
-                    data: JSON.stringify({id: id}),
+                    data: JSON.stringify({ id: id }),
                     contentType: 'application/json'
                 });
             };
@@ -206,7 +219,7 @@ function loadQueue(id) {
                     Del
                 </div>
             </div>`;
-        $.each(rows, function(i, obj) {
+        $.each(rows, function (i, obj) {
             target.appendChild(obj);
         });
     });

--- a/static/frontend/admin/adminpage.html
+++ b/static/frontend/admin/adminpage.html
@@ -1,59 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
 
-    <link rel = "stylesheet" type = "text/css" href = "./adminstyle.css">
+    <link rel="stylesheet" type="text/css" href="./adminstyle.css">
 
     <title>Mugi - Admin</title>
 </head>
+
 <body>
 
-<h1 id = "nowPlaying">Now Playing</h1>
-<div id = "controls">
-    <button id = "advance" class = "settings">Advance</button>
-    <br>
-    <button id = "activate" class = "settings">Activate</button>
-    <button id = "deactivate" class = "settings">Deactivate</button>
-    <br>
-    <button id = "activater" class = "settings">Activate Requests</button>
-    <button id = "deactivater" class = "settings">Deactivate Requests</button>
-    <br><br>
-    <button id = "removeActivate" class = "settings">Remove Singer</button>
-    <br><br>
-    <button id = "resetActivate" class = "settings">Reset Queue (DANGER)</button>
-    <div class = "settings__input">
-        Number of singers (1-4): <input type="number" name="singersInput" min="1" max="4">
-    </div>
-</div>
-
-
-
-<!-- Singer Removal Modal -->
-<div id="removeModal" class="modal">
-    <!-- Modal content -->
-    <div class="modal-content">
-        <span id="close_remove" class="close">&times;</span>
-        <div id = removeBox>
-            <input name = "Singer Name" id = "removeName" class = "textBox"></input><br>
-            <button id = "sendDelete" class = "settings">Submit</button>
+    <h1 id="nowPlaying">Now Playing</h1>
+    <div id="controls">
+        <button id="advance" class="settings">Advance</button>
+        <br>
+        <button id="activate" class="settings">Activate</button>
+        <button id="deactivate" class="settings">Deactivate</button>
+        <br>
+        <button id="activater" class="settings">Activate Requests</button>
+        <button id="deactivater" class="settings">Deactivate Requests</button>
+        <br><br>
+        <button id="removeActivate" class="settings">Remove Singer</button>
+        <br><br>
+        <button id="resetActivate" class="settings">Reset Queue (DANGER)</button>
+        <div class="settings__input">
+            Number of singers (1-4): <input type="number" name="singersInput" min="1" max="4">
+        </div>
+        <div class="settings__input">
+            Allow duplicate songs
+            <label class="switch">
+                <input type="checkbox" name="allowDuplicates" checked>
+                <span class="slider round"></span>
+            </label>
         </div>
     </div>
-</div>
 
-<!-- Reset Modal -->
-<div id="resetModal" class="modal">
-    <!-- Modal content -->
-    <div class="modal-content">
-        <span id="close_reset" class="close">&times;</span>
-        <div id = resetBox>
-          <p>Are you really sure you want to do this?</p>
-          <button id = "sendReset" class = "settings">Do it.</button>
+
+
+    <!-- Singer Removal Modal -->
+    <div id="removeModal" class="modal">
+        <!-- Modal content -->
+        <div class="modal-content">
+            <span id="close_remove" class="close">&times;</span>
+            <div id=removeBox>
+                <input name="Singer Name" id="removeName" class="textBox"></input><br>
+                <button id="sendDelete" class="settings">Submit</button>
+            </div>
         </div>
     </div>
-</div>
 
-<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-<script src="./admin.js"></script>
+    <!-- Reset Modal -->
+    <div id="resetModal" class="modal">
+        <!-- Modal content -->
+        <div class="modal-content">
+            <span id="close_reset" class="close">&times;</span>
+            <div id=resetBox>
+                <p>Are you really sure you want to do this?</p>
+                <button id="sendReset" class="settings">Do it.</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="./admin.js"></script>
 </body>
+
 </html>

--- a/static/frontend/admin/adminstyle.css
+++ b/static/frontend/admin/adminstyle.css
@@ -139,3 +139,67 @@
         display: block;
     }
 }
+
+/* The switch - the box around the slider */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 80px;
+    height: 34px;
+    margin-left: 50px;
+  }
+  
+  /* Hide default HTML checkbox */
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(45px);
+    -ms-transform: translateX(45px);
+    transform: translateX(45px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }

--- a/webserver/admin.go
+++ b/webserver/admin.go
@@ -14,6 +14,7 @@ func RouteAdmin(group *gin.RouterGroup) {
 	group.POST("/remove_singer", removeSingerEndpoint)
 	group.POST("/reset_queue", resetQueueEndpoint)
 	group.POST("/singers/:number", changeNumberOfSingersEndpoint)
+	group.POST("/allowdupes/:bool", allowDuplicatesEndpoint)
 }
 
 func resetQueueEndpoint(c *gin.Context) {
@@ -110,5 +111,17 @@ func changeNumberOfSingersEndpoint(c *gin.Context) {
 	singersString := c.Param("number")
 	singers, _ := strconv.Atoi(singersString)
 	manager.ChangeNumberOfSingers(env, singers)
+	c.Status(201)
+}
+
+func allowDuplicatesEndpoint(c *gin.Context) {
+	env, ok := c.MustGet("manager").(*manager.KaraokeManager)
+	if !ok {
+		env.Logger.Printf("Failed to grab environment from Context variable")
+		c.String(500, "{\"message\": \"internal failure\"")
+	}
+	allowDupesString := c.Param("bool")
+	allowDupes, _ := strconv.ParseBool(allowDupesString)
+	manager.ChangeAllowDuplication(env, allowDupes)
 	c.Status(201)
 }


### PR DESCRIPTION
A toggle switch has been added to the admin panel that allows controlling
whether duplicate songs should be allowed in the queue. This is accomplished by
new endpoint admin/allowdupes. This new control will allow the admin to
turn off duplicate songs during a live session. When the setting is toggled,
the awaiting queue will be refreshed accordingly. Note, however, this will not
affect the upcoming songs queue.

Also auto-lint code style on a few files.