### PR TITLE
Add server IP address to admin page

### DIFF
--- a/static/frontend/admin/admin.js
+++ b/static/frontend/admin/admin.js
@@ -35,6 +35,9 @@ function AdminPanel() {
         admin.active = JSON.parse(e.data).active;
     });
 
+    $.get('/admin/ipaddress', null, (ipaddress) => {
+        $('#serverDetails__ip-address').text(ipaddress);
+    });
 
     //Functions for updating display elements
     this.setPlaying = function () {

--- a/static/frontend/admin/adminpage.html
+++ b/static/frontend/admin/adminpage.html
@@ -10,7 +10,9 @@
 </head>
 
 <body>
-
+    <div id="serverDetails">
+        Server IP Address: <span id="serverDetails__ip-address"></span>
+    </div>
     <h1 id="nowPlaying">Now Playing</h1>
     <div id="controls">
         <button id="advance" class="settings">Advance</button>


### PR DESCRIPTION
This allows users to know what the server ip address is, which is useful
in case tech support wants to connect to the server while the DJ is busy.