### PR TITLE
Fix CSS issues on display page

### DIFF
--- a/static/frontend/display/display.css
+++ b/static/frontend/display/display.css
@@ -105,7 +105,7 @@ body {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     text-align: center;
     color: white;
-    width: fit-content;
+    max-width: 450px;
     height: 70vh;
     background: #2b2b2b;
 }
@@ -121,7 +121,7 @@ body {
 }
 
 #nowplaying h2 {
-    font-size: 40pt;
+    font-size: 2.5rem;
     margin:0;
 }
 
@@ -140,16 +140,31 @@ body {
     height: 55%;
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
+    place-content: flex-start;
     margin: 10px 30px 10px 30px;
     overflow: scroll;
+    /* For firefox */
+    scrollbar-color: rgba(0,0,0,.5) rgba(0,0,0,0);
+    scrollbar-width: thin;
 }
 
 #queue::-webkit-scrollbar {
-    display: none;
+    display: block;
 }
 
+#queue::-webkit-scrollbar:vertical {
+    width: 10px;
+}
+  
+#queue::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
+#queue::-webkit-scrollbar-corner {
+    background-color: transparent;
+}
 
 .queueitem {
     border-radius: 5px;
@@ -195,10 +210,27 @@ body {
   flex-direction: column;
   flex-wrap: wrap;
   padding: 5px 0;
+  /* For firefox */
+  scrollbar-color: rgba(0,0,0,.5) rgba(0,0,0,0);
+  scrollbar-width: thin;
 }
 
 #waiting::-webkit-scrollbar {
-    display: none;
+    display: block;
+}
+
+#waiting::-webkit-scrollbar:horizontal {
+    height: 10px;
+}
+  
+#waiting::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
+::-webkit-scrollbar-corner {
+    background-color: transparent;
 }
 
 .partialItem {
@@ -271,6 +303,7 @@ body {
 @media only screen and (max-width: 1366px) {
     #nowplaying {
       width: 450px;
+      max-width: unset;
     }
 
     .mainbody_title {
@@ -281,10 +314,6 @@ body {
         font-size: 45pt;
     }
 
-    #nowplaying h2 {
-        font-size: 35pt;
-    }
-
     #leftbar {
         width: fit-content;
     }
@@ -292,20 +321,6 @@ body {
 
 /* For mobile screens */
 @media only screen and (max-width: 1024px) {
-
-    #queue::-webkit-scrollbar {
-        display: block;
-    }
-
-    #queue::-webkit-scrollbar:vertical {
-        width: 10px;
-    }
-      
-    #queue::-webkit-scrollbar-thumb {
-        border-radius: 5px;
-        background-color: rgba(0,0,0,.5);
-        -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
-    }
 
     #queue {
         height: 550px;
@@ -376,23 +391,5 @@ body {
 
     #waiting {
         height: 340px;
-    }
-
-    #waiting::-webkit-scrollbar {
-        display: block;
-    }
-
-    #waiting::-webkit-scrollbar:horizontal {
-        height: 10px;
-    }
-      
-    #waiting::-webkit-scrollbar-thumb {
-        border-radius: 5px;
-        background-color: rgba(0,0,0,.5);
-        -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
-    }
-
-    ::-webkit-scrollbar-corner {
-        background-color: transparent;
     }
 }


### PR DESCRIPTION
- Set max-width of playing element to account for large cover art
- Enable scrollbar on all screen sizes to make it clear the queues can be
  scrolled
- Firefox doesn't support webkit styling so use scrollbar-* css properties to
  make it similar for now
- Queue items now fill space from the top instead of the middle