### PR TITLE
Fix issue where requests do not go above 2 singers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh        eol=lf
+* text=auto

--- a/static/frontend/display/display.js
+++ b/static/frontend/display/display.js
@@ -186,7 +186,7 @@ function makePartialQueueDivs(queue, prevQueueDivs, nowPlaying, targetDiv, noSin
     let newQueueDisplay = {};
     if (queue.partial != null) {
       queue.partial.map((q_entry, index) => {
-          itemid = q_entry.ids.join(".");
+          itemid = q_entry.ids.join("");
           if (!prevQueueDivs.hasOwnProperty(itemid)) {
               //Make a new div
               let newdiv = $('<div/>')


### PR DESCRIPTION
In display.js we create div ids for the waiting items by
joining the queue item's request IDs via a '.' character. However
later we try to use jQuery to remove divs based on these IDs
which fail as it doesn't recognise the dots. This results in multiple
cards being shown for the same song. This is resolved not joining
the ids with a '.' as it's not needed anyway.